### PR TITLE
Suppressed PHP warnings for rename and unlink operations

### DIFF
--- a/src/Convert/Converters/AbstractConverter.php
+++ b/src/Convert/Converters/AbstractConverter.php
@@ -261,7 +261,7 @@ abstract class AbstractConverter
         if (!@file_exists($destination)) {
             throw new ConversionFailedException('Destination file is not there: ' . $destination);
         } elseif (@filesize($destination) === 0) {
-            unlink($destination);
+            @unlink($destination);
             throw new ConversionFailedException('Destination file was completely empty');
         } else {
             if (!isset($this->options['_suppress_success_message'])) {

--- a/src/Convert/Converters/BaseTraits/DestinationPreparationTrait.php
+++ b/src/Convert/Converters/BaseTraits/DestinationPreparationTrait.php
@@ -71,7 +71,7 @@ trait DestinationPreparationTrait
         if (file_put_contents($destination, 'dummy') !== false) {
 			if (file_exists($destination)) {
 				// all is well, after all
-				unlink($destination);
+				@unlink($destination);
 			}
             return;
         }
@@ -93,7 +93,7 @@ trait DestinationPreparationTrait
         if (file_exists($destination)) {
             // A file already exists in this folder...
             // We delete it, to make way for a new webp
-            if (!unlink($destination)) {
+            if (!@unlink($destination)) {
                 throw new CreateDestinationFileException(
                     'Existing file cannot be removed: ' . basename($destination)
                 );

--- a/src/Convert/Converters/ConverterTraits/EncodingAutoTrait.php
+++ b/src/Convert/Converters/ConverterTraits/EncodingAutoTrait.php
@@ -70,19 +70,19 @@ trait EncodingAutoTrait
 		if (file_exists($destinationLossless) && file_exists($destinationLossy)) {
 			if (filesize($destinationLossless) > filesize($destinationLossy)) {
 				$this->logLn('Picking lossy');
-				unlink($destinationLossless);
-				rename($destinationLossy, $destination);
+				@unlink($destinationLossless);
+				@rename($destinationLossy, $destination);
 			} else {
 				$this->logLn('Picking lossless');
-				unlink($destinationLossy);
-				rename($destinationLossless, $destination);
+				@unlink($destinationLossy);
+				@rename($destinationLossless, $destination);
 			}
 		} else {
 			if (file_exists($destinationLossless)) {
-				rename($destinationLossless, $destination);
+				@rename($destinationLossless, $destination);
 			}
 			if (file_exists($destinationLossy)) {
-				rename($destinationLossy, $destination);
+				@rename($destinationLossy, $destination);
 			}
 		}
         $this->setDestination($destination);

--- a/src/Convert/Converters/Gd.php
+++ b/src/Convert/Converters/Gd.php
@@ -323,7 +323,7 @@ class Gd extends AbstractConverter
     {
         imagedestroy($image);
         if (file_exists($this->destination)) {
-            unlink($this->destination);
+            @unlink($this->destination);
         }
     }
 

--- a/tests/Serve/ServeConvertedWebPTest.php
+++ b/tests/Serve/ServeConvertedWebPTest.php
@@ -425,7 +425,7 @@ class ServeConvertedWebPTest extends CompatibleTestCase
         ];
         $result = self::callServeWithThrow($source, $source . '.webp', $options);
 
-        unlink($destination);
+        @unlink($destination);
 
         // Our success-converter always creates fake webps with the content:
         // "we-pretend-this-is-a-valid-webp!".


### PR DESCRIPTION
@DavidAnderson684 

Often I get the following warnings in the debug log:

```
Warning: unlink(wp-content/uploads/sites/2/wpo/images/wpo_logo_small.png.webp.lossless.webp): No such file or directory in /media/k/SSD/xampp/htdocs/updraft/optimize/wp-content/wp-optimize/dist/vendor/rosell-dk/webp-convert/src/Convert/Converters/ConverterTraits/EncodingAutoTrait.php on line 73

Warning: rename(wp-content/uploads/sites/2/wpo/images/wpo_logo_small.png.webp.lossy.webp,wp-content/uploads/sites/2/wpo/images/wpo_logo_small.png.webp): No such file or directory in /media/k/SSD/xampp/htdocs/updraft/optimize/wp-content/wp-optimize/dist/vendor/rosell-dk/webp-convert/src/Convert/Converters/ConverterTraits/EncodingAutoTrait.php on line 74

Warning: rename(wp-content/uploads/wpo/images/wpo_logo_small.png.webp.lossy.webp,wp-content/uploads/wpo/images/wpo_logo_small.png.webp): No such file or directory in /media/k/SSD/xampp/htdocs/updraft/optimize/wp-content/wp-optimize/dist/vendor/rosell-dk/webp-convert/src/Convert/Converters/ConverterTraits/EncodingAutoTrait.php on line 85

Warning: unlink(wp-content/uploads/wpo/images/wpo_logo_small.png.webp): No such file or directory in /media/k/SSD/xampp/htdocs/updraft/optimize/wp-content/wp-optimize/dist/vendor/rosell-dk/webp-convert/src/Convert/Converters/BaseTraits/DestinationPreparationTrait.php on line 96
```

This PR suppresses these warnings. 